### PR TITLE
Makefile improvements

### DIFF
--- a/NoFramework/Makefile
+++ b/NoFramework/Makefile
@@ -21,34 +21,39 @@ all: install
 #	$(error wrk is not installed)
 #endif
 
-install:
+
+venv:
 	@echo "Creating virtual environment and downloading requirements"
-	python3 -m venv venv
-	. venv/bin/activate; \
-	pip install -r requirements.txt; 
+	python3 -m venv venv && \
+	    . venv/bin/activate; \
+	    pip install wheel && \
+	    pip install -r requirements.txt;
+
+install: venv
+
 ifdef wrkVersion
 	@echo "wrk is properly installed"
 else
 	$(error wrk is not installed)
 endif
 
-gunicorn:
+gunicorn: venv
 	$(virtualEnv); \
 	gunicorn -w 9 -b 0.0.0.0:5000 app:application
 
-meinheld:
+meinheld: venv
 	$(virtualEnv); \
 	gunicorn -w 9 -b 0.0.0.0:5000 --worker-class=meinheld.gmeinheld.MeinheldWorker app:application
 
-uwsgi:
+uwsgi: venv
 	$(virtualEnv); \
 	uwsgi --http :5000 --wsgi-file app.py --master --processes 9 --enable-threads
 
-cherrypy:
+cherrypy: venv
 	$(virtualEnv); \
-    python cherrypy.wsgi
+        python cherrypy.wsgi
 
-test:
+test: venv
 	@echo "running tests now ..."
 	sleep 5
 	wrk -t4 -c$(connection) -d30s http://127.0.0.1:5000/ | tee -a results/$(result)

--- a/NoFramework/requirements.txt
+++ b/NoFramework/requirements.txt
@@ -2,3 +2,4 @@ gunicorn==19.6.0
 meinheld==0.6.1
 uWSGI==2.0.15
 cherrypy==3.5.0
+


### PR DESCRIPTION
* Have targets depend upon the presence of the `venv` directory
* Install `wheel` to silence `bdist_wheel` target failures
* Fail early if `virtualenv` invocation fails.